### PR TITLE
Support for Microsoft custom ARF format

### DIFF
--- a/eg/maildir-as-a-sample/new/arf-13.eml
+++ b/eg/maildir-as-a-sample/new/arf-13.eml
@@ -1,0 +1,76 @@
+Delivered-To: arf@example.com
+Received: by 10.182.89.225 with SMTP id br1csp740877obb;
+        Tue, 21 Apr 2015 09:22:16 -0700 (PDT)
+X-Received: by 10.67.3.195 with SMTP id by3mr38900527pad.109.1429633335303;
+        Tue, 21 Apr 2015 09:22:15 -0700 (PDT)
+Return-Path: <staff@hotmail.com>
+Received: from BAY004-OMC3S6.hotmail.com (bay004-omc3s6.hotmail.com. [65.54.190.144])
+        by mx.example.com with ESMTPS id t2si3581725pdh.156.2015.04.21.09.22.14
+        for <arf@example.com>
+        (version=TLSv1.2 cipher=ECDHE-RSA-AES128-SHA bits=128/128);
+        Tue, 21 Apr 2015 09:22:15 -0700 (PDT)
+Received: from BAY0-XMR-027.phx.gbl ([65.54.190.187]) by BAY004-OMC3S6.hotmail.com with Microsoft SMTPSVC(7.5.7601.22751);
+	 Tue, 21 Apr 2015 09:22:14 -0700
+Received: from mail pickup service by BAY0-XMR-027.phx.gbl with Microsoft SMTPSVC;
+	 Tue, 21 Apr 2015 09:22:14 -0700
+Date: Tue, 21 Apr 2015 09:22:13 -0700
+From: staff@hotmail.com
+Subject:  complaint about message from 123.123.123.123
+To: arf@example.com
+MIME-Version:  1.0 
+Content-Type: multipart/mixed; boundary="B2E4395D-05AB-4EAF-8557-699F69427353"
+Message-ID: <BAY0-XMR-027Y1mfKb000f565d4@BAY0-XMR-027.phx.gbl>
+X-OriginalArrivalTime: 21 Apr 2015 16:22:14.0182 (UTC) FILETIME=[53AC8460:01D07C4F]
+Return-Path: staff@hotmail.com
+
+--B2E4395D-05AB-4EAF-8557-699F69427353
+Content-Type: message/rfc822
+Content-Disposition: inline
+
+X-HmXmrOriginalRecipient: recipient@hotmail.com
+X-Reporter-IP: 123.123.123.124
+X-Message-Guid: ebfba2c7-e82b-11e4-be08-002264c15484
+x-store-info:J++/JTCzmObr++wNraA4Pa4f5Xd6uensqBPWJv3GwGE7aUR5jJQTkPrgUUBlc7+CY+WY7UEuW6SMFsHHYZFIJgBtuL8CSIF+YE1T+EJsu/qunn9dJ/+DQN2V2BN4xF7gzV9vefMymd8=
+Authentication-Results: hotmail.com; spf=pass (sender IP is 123.123.123.123; identity alignment result is pass and alignment mode is relaxed) smtp.mailfrom=sender@example.com; dkim=pass (identity alignment result is pass and alignment mode is relaxed) header.d=example.com; x-hmca=pass header.id=sender@example.com
+X-SID-PRA: sender@example.com
+X-AUTH-Result: PASS
+X-SID-Result: PASS
+X-Message-Status: n:n
+X-Message-Delivery: Vj0xLjE7dXM9MDtsPTE7YT0xO0Q9MTtHRD0xO1NDTD0w
+X-Message-Info: NhFq/7gR1vSNR7oR+vyPYQjkMnWBEu9uyBw1y9eFMXUE+Eyh/YdM5MkBsA9YADpYPRNX1QD8N61UwtG4ltHmCELHKCRVqF4G3Sz3ixJ1EjQx6m20O44Ef284ZptMLJGyU+Bw4W/7t5swJDxQ3qFJwjuq2Qc+7JUknVKshE25gNICB6zDUjfrdnByg4nnuDCkK/ZwF0H/IuMZpI0p3nLisKim1TM33aZ9
+Received: from smtp.example.com ([123.123.123.123]) by SNT004-MC2F52.hotmail.com over TLS secured channel with Microsoft SMTPSVC(7.5.7601.23008);
+	 Tue, 21 Apr 2015 06:40:12 -0700
+Date: Tue, 21 Apr 2015 15:40:10 +0200
+To: recipient@hotmail.com
+From: ACME Corp. <sender@example.com>
+Reply-To: ACME Corp.
+ <sender@example.com>
+Subject: Example message
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/html; charset="utf-8"
+Message-ID: <d4cb0d6593464552a34f4429b3e7f92f@example.com>
+Precedence: bulk
+List-Unsubscribe: <mailto:unsubscribe@example.com?subject=Unsubscription%20request>
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=example.com;
+ i=@example.com; q=dns/txt; s=dkim1; t=1429623611; h=Date : 
+ To : From : Reply-To : Subject : MIME-Version : 
+ Content-Transfer-Encoding : Content-Type : Message-ID : 
+ List-Unsubscribe : Date : From : Subject; 
+ bh=obgp51Mvvcje/wo8zRJINx38SUn5XdM/wyyihBckJUI=; 
+ b=X5Qc/ZimMAGP0NNDCIwwTaE35ru7CmsqR1xexARA9TnnKGDzFBiiuDSs6p+SAtcIkU2i0n
+ zSJlkGgRo0fEQ4dcc99hmR3XO46SIo8kNWfHZdsuXSt+Iqahb5HhOz9bBJ0rBiPdiLC0GG+H
+ Lhk287RLSSQDdvNBVDg28HBuQuiy4=
+Return-Path: sender@example.com
+X-OriginalArrivalTime: 21 Apr 2015 13:40:13.0168 (UTC) FILETIME=[B17F7F00:01D07C38]
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+ xmlns:v="urn:schemas-microsoft-com:vml"
+ xmlns:o="urn:schemas-microsoft-com:office:office">
+[...]
+</html>
+
+
+--B2E4395D-05AB-4EAF-8557-699F69427353--

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -325,7 +325,7 @@ sub rewrite {
         # 3. Sisimai::MSP::*
         # 4. Sisimai::RFC3464
         #
-        if( Sisimai::ARF->is_arf( $mailheader->{'content-type'} ) ) {
+        if( Sisimai::ARF->is_arf( $mailheader ) ) {
             # Feedback Loop message
             $scannedset = Sisimai::ARF->scan( $mailheader, $bodystring );
             last(SCANNER) if $scannedset;

--- a/t/101-arf.t
+++ b/t/101-arf.t
@@ -24,6 +24,7 @@ my $ReturnValue = {
     '10' => { 'status' => qr/\A\z/, 'reason' => qr/feedback/, 'feedbacktype' => qr/abuse/ },
     '11' => { 'status' => qr/\A\z/, 'reason' => qr/feedback/, 'feedbacktype' => qr/abuse/ },
     '12' => { 'status' => qr/\A\z/, 'reason' => qr/feedback/, 'feedbacktype' => qr/opt-out/ },
+    '13' => { 'status' => qr/\A\z/, 'reason' => qr/feedback/, 'feedbacktype' => qr/abuse/ },
 };
 
 use_ok $PackageName;
@@ -40,7 +41,7 @@ MAKE_TEST: {
     isa_ok $PackageName->headerlist, 'ARRAY';
 
     is $PackageName->scan, undef, '->scan';
-    is $PackageName->is_arf( 'multipart/report; report-type=feedback-report;'), 1;
+    is $PackageName->is_arf( { 'content-type' => 'multipart/report; report-type=feedback-report;' } ), 1;
 
     use Sisimai::Data;
     use Sisimai::Mail;


### PR DESCRIPTION
Hi, 

This pull request add support for Microsoft (Hotmail, MSN, Live, Outlook) ARF implementation, which is different from the "real" ARF format (RFC 6650).
The `X-HmXmrOriginalRecipient`, `X-Reporter-IP` and `X-Message-Guid` headers are added to the message reported as spam, and send as an RFC 822 attachment.

Sample output: 
```json
{
  "action": "failed",
  "addresser": "sender@example.com",
  "alias": "",
  "deliverystatus": "",
  "destination": "hotmail.com",
  "diagnosticcode": "This is a Microsoft email abuse report for an email message received from IP 123.123.123.123 on Tue, 21 Apr 2015 09:22:13 -0700",
  "diagnostictype": "SMTP",
  "feedbacktype": "abuse",
  "lhost": "10.182.89.225",
  "listid": "",
  "messageid": "d4cb0d6593464552a34f4429b3e7f92f@example.com",
  "reason": "feedback",
  "recipient": "recipient@hotmail.com",
  "rhost": "123.123.123.123",
  "senderdomain": "example.com",
  "smtpagent": "Microsoft Junk Mail Reporting Program",
  "smtpcommand": "",
  "subject": "Example message",
  "timestamp": 1429633333,
  "timezoneoffset": "-0700",
  "token": "d86ca075c5c1b81d97bd0a56b5fdb58a1a182993"
}
```